### PR TITLE
clone members instead of pushing to avoid mutate defaultMembers

### DIFF
--- a/src/models/user-group.ts
+++ b/src/models/user-group.ts
@@ -77,10 +77,12 @@ export default class UserGroup extends Model {
       return invitation as GroupInvitation;
     }
     const invitation = await GroupInvitation.makeInvitation(username, this);
-    this.attrs.members.push({
-      username,
-      inviteId: invitation._id,
-    });
+
+    this.attrs.members = [
+      ...this.attrs.members,
+      { username, inviteId: invitation._id },
+    ];
+
     await this.save();
     return invitation;
   }


### PR DESCRIPTION
# Problem

The current code inside `UserGroup` pushes members to its `attrs.members` mutating the `defaultMembers` constant.

After that, a new group will be initialized with the new `defaultMembers` state that includes the members added to the previous group.


# Solution

Use the spread syntax to avoid mutations.