### PR TITLE
Pass `updatedAt` to radiks-server delete API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Radiks-js Changelog
 
+## 0.2.2-beta.1 - November 18th, 2019
+
+Passes the `updatedAt` attribute to the "destroy" API in `radiks-server`. This is required to work with [`radiks-server` issue #30](https://github.com/blockstack/radiks-server/pull/30).
+
 ## 0.2.1 - June 9th, 2019
 
 Thanks to @pradel for contributing most of the work in this release!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radiks",
-  "version": "0.2.1",
+  "version": "0.2.2-beta.1",
   "description": "Manage models with encryption and decentralized storage",
   "main": "lib/index.js",
   "author": "Hank Stoever",

--- a/src/api.ts
+++ b/src/api.ts
@@ -77,12 +77,12 @@ export const fetchCentral = async (key: string, username: string, signature: str
 
 export const destroyModel = async (model: Model) => {
   const { apiServer } = getConfig();
-  const queryString = stringify({ signature: model.attrs.radiksSignature });
+  const { updatedAt } = model.attrs;
+  const queryString = stringify({ signature: model.attrs.radiksSignature, updatedAt });
   const url = `${apiServer}/radiks/models/${model._id}?${queryString}`;
   const response = await fetch(url, {
     method: 'DELETE',
   });
   const data = await response.json();
-  console.log(data);
   return data.success;
 };

--- a/src/model.ts
+++ b/src/model.ts
@@ -125,6 +125,7 @@ export default class Model {
           await this.beforeSave();
         }
         const now = new Date().getTime();
+        this.attrs.updatedAt = now;
         this.attrs.createdAt = this.attrs.createdAt || now;
         this.attrs.updatedAt = now;
         await this.sign();
@@ -306,6 +307,8 @@ export default class Model {
   }
 
   async destroy(): Promise<boolean> {
+    const now = new Date().getTime();
+    this.attrs.updatedAt = now;
     await this.sign();
     await this.deleteFile();
     return destroyModel(this);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -71,14 +71,16 @@ test('it signs ID with the signing key private key', async () => {
 });
 
 test('it can delete a model', async () => {
-  const user = await User.createWithCurrentUser();
+  await User.createWithCurrentUser();
   const model = fakeModel();
   let deleteFileWasCalled = false;
   model.deleteFile = () => {
     deleteFileWasCalled = true;
   };
   await model.save();
+  const { updatedAt } = model.attrs;
   await model.destroy();
+  expect(model.attrs.updatedAt).toBeGreaterThan(updatedAt);
   expect(deleteFileWasCalled).toBeTruthy();
   const fetched = await TestModel.fetchList({}, { decrypt: false });
   expect(fetched.find(m => m._id === model._id)).toBeFalsy();


### PR DESCRIPTION
Passes the `updatedAt` attribute to the "destroy" API in `radiks-server`. This is required to work with [`radiks-server` issue #30](https://github.com/blockstack/radiks-server/pull/30).