### PR TITLE
radiks fix for advanced query support

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -28,7 +28,7 @@ export interface FindQuery {
 
 export const find = async (query: FindQuery) => {
   const { apiServer } = getConfig();
-  const queryString = stringify(query, { arrayFormat: 'brackets', encode: false });
+  const queryString = stringify(query, { encode: false });
   const url = `${apiServer}/radiks/models/find?${queryString}`;
   const response = await fetch(url);
   const data = await response.json();
@@ -37,7 +37,7 @@ export const find = async (query: FindQuery) => {
 
 export const count = async (query: FindQuery) => {
   const { apiServer } = getConfig();
-  const queryString = stringify(query, { arrayFormat: 'brackets', encode: false });
+  const queryString = stringify(query, { encode: false });
   const url = `${apiServer}/radiks/models/count?${queryString}`;
   const response = await fetch(url);
   const data = await response.json();


### PR DESCRIPTION
Removed "arrayFormat=brackets" from all places where qs.stringify  is called, because it doesn't work correctly with advanced search queries (default arrayFormat=indices works good). More information about the qs issue here: https://github.com/ljharb/qs/issues/215

This commit is a part of fix to https://github.com/blockstack/radiks/issues/67. The second part is in the radiks-server repository