### PR TITLE
Use md5 hash of app public key to identify a user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ typed
 yarn-debug.log*
 yarn-error.log*
 .env
+
+.idea/
+
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "radiks",
-  "version": "0.2.1",
+  "name": "radiks-patch",
+  "version": "0.1.1",
   "description": "Manage models with encryption and decentralized storage",
   "main": "lib/index.js",
   "author": "Hank Stoever",
@@ -40,6 +40,7 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
+    "blueimp-md5": "^2.12.0",
     "faker": "^4.1.0",
     "qs": "^6.5.2",
     "query-string": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radiks-patch",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "description": "Manage models with encryption and decentralized storage",
   "main": "lib/index.js",
   "author": "Hank Stoever",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,7 @@
+import md5 from 'blueimp-md5';
+
 import { encryptECIES, decryptECIES } from 'blockstack/lib/encryption';
+import { getPublicKeyFromPrivate } from 'blockstack/lib/keys';
 import { getConfig } from './config';
 import Model from './model';
 import { SchemaAttribute } from './types';
@@ -127,4 +130,23 @@ export const loadUserData = () => {
     return userSession.loadUserData();
   }
   return null;
+};
+
+
+export interface CustomWindow extends Window {
+  reservedUsers: [string];
+}
+
+declare let window: CustomWindow;
+
+export const currentUserId = (): string => {
+  const userData = loadUserData();
+  const { username, appPrivateKey } = userData;
+
+  if (username && window.reservedUsers && window.reservedUsers.includes(username)) {
+    return username;
+  }
+
+  const publicKey = getPublicKeyFromPrivate(appPrivateKey);
+  return md5(publicKey);
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -134,7 +134,7 @@ export const loadUserData = () => {
 
 
 export interface CustomWindow extends Window {
-  reservedUsers: [string];
+  _reservedUsersNames: [string];
 }
 
 declare let window: CustomWindow;
@@ -143,7 +143,7 @@ export const currentUserId = (): string => {
   const userData = loadUserData();
   const { username, appPrivateKey } = userData;
 
-  if (username && window.reservedUsers && window.reservedUsers.includes(username)) {
+  if (username && window._reservedUsersNames && window._reservedUsersNames.includes(username)) {
     return username;
   }
 

--- a/src/models/group-membership.ts
+++ b/src/models/group-membership.ts
@@ -2,7 +2,7 @@ import Model from '../model';
 import User from './user';
 import UserGroup from './user-group';
 import {
-  clearStorage, userGroupKeys, GROUP_MEMBERSHIPS_STORAGE_KEY, loadUserData,
+  clearStorage, userGroupKeys, GROUP_MEMBERSHIPS_STORAGE_KEY, loadUserData, currentUserId,
 } from '../helpers';
 import SigningKey from './signing-key';
 import { Attrs } from '../types/index';
@@ -49,7 +49,7 @@ export default class GroupMembership extends Model {
   static async cacheKeys() {
     const { userGroups, signingKeys } = await this.fetchUserGroups();
     const groupKeys = userGroupKeys();
-    const self = await User.findById(loadUserData().username);
+    const self = await User.findById(currentUserId());
     const key = await SigningKey.findById(self.attrs.personalSigningKeyId);
     groupKeys.personal = key.attrs;
     groupKeys.signingKeys = signingKeys;

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -4,7 +4,7 @@ import { signECDSA } from 'blockstack/lib/encryption';
 import Model from '../model';
 import SigningKey from './signing-key';
 import GroupMembership from './group-membership';
-import { addPersonalSigningKey, loadUserData } from '../helpers';
+import { addPersonalSigningKey, loadUserData, currentUserId } from '../helpers';
 import { Schema } from '../types/index';
 
 const decrypted = true;
@@ -42,7 +42,7 @@ export default class BlockstackUser extends Model {
     const publicKey = getPublicKeyFromPrivate(appPrivateKey);
     const Clazz = this;
     const user = new Clazz({
-      _id: username,
+      _id: currentUserId(),
       username,
       publicKey,
       profile,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,6 +1425,11 @@ blockstack@19.2.1:
     uuid "^3.3.2"
     zone-file "^1.0.0"
 
+blueimp-md5@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.12.0.tgz#be7367938a889dec3ffbb71138617c117e9c130a"
+  integrity sha512-zo+HIdIhzojv6F1siQPqPFROyVy7C50KzHv/k/Iz+BtvtVzSHXiMXOpq2wCfNkeBqdCv+V8XOV96tsEt2W/3rQ==
+
 bn.js@^4.0.0, bn.js@^4.11.8, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"


### PR DESCRIPTION
This PR
* uses the md5 hash of the app public key to identify users instead of usernames.