### PR TITLE
Don't encrypt signing key id

### DIFF
--- a/src/models/group-invitation.ts
+++ b/src/models/group-invitation.ts
@@ -6,8 +6,8 @@ import { userGroupKeys, loadUserData } from '../helpers';
 import { Schema, Attrs } from '../types/index';
 
 interface GroupInvitationAttrs extends Attrs {
-  userGroupId?: string | Record<string, any>,
-  signingKeyPrivateKey?: string | Record<string, any>,
+  userGroupId?: string | Record<string, any>;
+  signingKeyPrivateKey?: string | Record<string, any>;
 }
 
 export default class GroupInvitation extends Model {
@@ -17,12 +17,15 @@ export default class GroupInvitation extends Model {
   static schema: Schema = {
     userGroupId: String,
     signingKeyPrivateKey: String,
-    signingKeyId: String,
-  }
+    signingKeyId: {
+      type: String,
+      decrypted: true,
+    },
+  };
 
   static defaults = {
     updatable: false,
-  }
+  };
 
   static async makeInvitation(username: string, userGroup: UserGroup) {
     const user = new User({ _id: username });

--- a/src/models/group-membership.ts
+++ b/src/models/group-membership.ts
@@ -2,18 +2,21 @@ import Model from '../model';
 import User from './user';
 import UserGroup from './user-group';
 import {
-  clearStorage, userGroupKeys, GROUP_MEMBERSHIPS_STORAGE_KEY, loadUserData,
+  clearStorage,
+  userGroupKeys,
+  GROUP_MEMBERSHIPS_STORAGE_KEY,
+  loadUserData,
 } from '../helpers';
 import SigningKey from './signing-key';
 import { Attrs } from '../types/index';
 
 interface UserGroupKeys {
   userGroups: {
-    [userGroupId: string]: string,
-  },
+    [userGroupId: string]: string;
+  };
   signingKeys: {
-    [signingKeyId: string]: string
-  }
+    [signingKeyId: string]: string;
+  };
 }
 
 export default class GroupMembership extends Model {
@@ -25,8 +28,11 @@ export default class GroupMembership extends Model {
       decrypted: true,
     },
     signingKeyPrivateKey: String,
-    signingKeyId: String,
-  }
+    signingKeyId: {
+      type: String,
+      decrypted: true,
+    },
+  };
 
   static async fetchUserGroups(): Promise<UserGroupKeys> {
     const { username } = loadUserData();
@@ -37,10 +43,12 @@ export default class GroupMembership extends Model {
     memberships.forEach(({ attrs }) => {
       signingKeys[attrs.signingKeyId] = attrs.signingKeyPrivateKey;
     });
-    const fetchAll = memberships.map(membership => membership.fetchUserGroupSigningKey());
+    const fetchAll = memberships.map(membership =>
+      membership.fetchUserGroupSigningKey()
+    );
     const userGroupList = await Promise.all(fetchAll);
     const userGroups: UserGroupKeys['userGroups'] = {};
-    userGroupList.forEach((userGroup) => {
+    userGroupList.forEach(userGroup => {
       userGroups[userGroup._id] = userGroup.signingKeyId;
     });
     return { userGroups, signingKeys };
@@ -54,7 +62,10 @@ export default class GroupMembership extends Model {
     groupKeys.personal = key.attrs;
     groupKeys.signingKeys = signingKeys;
     groupKeys.userGroups = userGroups;
-    localStorage.setItem(GROUP_MEMBERSHIPS_STORAGE_KEY, JSON.stringify(groupKeys));
+    localStorage.setItem(
+      GROUP_MEMBERSHIPS_STORAGE_KEY,
+      JSON.stringify(groupKeys)
+    );
   }
 
   static async clearStorage() {
@@ -76,9 +87,12 @@ export default class GroupMembership extends Model {
   }
 
   getSigningKey() {
-    const { signingKeyId, signingKeyPrivateKey }: {
-      signingKeyId?: string,
-      signingKeyPrivateKey?: string
+    const {
+      signingKeyId,
+      signingKeyPrivateKey,
+    }: {
+      signingKeyId?: string;
+      signingKeyPrivateKey?: string;
     } = this.attrs;
     return {
       _id: signingKeyId,
@@ -88,9 +102,11 @@ export default class GroupMembership extends Model {
 
   async fetchUserGroupSigningKey() {
     const _id: string = this.attrs.userGroupId;
-    const userGroup = await UserGroup.findById<UserGroup>(_id) as UserGroup;
-    const { signingKeyId }: {
-      signingKeyId?: string
+    const userGroup = (await UserGroup.findById<UserGroup>(_id)) as UserGroup;
+    const {
+      signingKeyId,
+    }: {
+      signingKeyId?: string;
     } = userGroup.attrs;
     return {
       _id,


### PR DESCRIPTION
This PR
* adds `decrypted:true ` for signing key ids of GroupMembership and GroupInvitation
* replaces #78 and #65 